### PR TITLE
Àdd extra exception to catch to deal with a change in XNATpy which al…

### DIFF
--- a/xnat4tests/base.py
+++ b/xnat4tests/base.py
@@ -145,7 +145,7 @@ def start_xnat(config_name="default", keep_mounts=False, rebuild=True, relaunch=
     for attempts in range(1, config.connection_attempts + 1):
         try:
             login = connect(config)
-        except (xnat.exceptions.XNATError, requests.ConnectionError):
+        except (xnat.exceptions.XNATError, requests.ConnectionError, requests.ReadTimeout):
             if attempts == config.connection_attempts:
                 raise
             else:


### PR DESCRIPTION
XNATpy now allows the initially requests to time out to avoid the possibility of hanging indefinitely  (see https://gitlab.com/radiology/infrastructure/xnatpy/-/commit/288df3149c8e88701d3375ae075e55d9bf2bc980). This can cause the exception raised by XNATpy when the connection cannot be made to change and trigger the exception breaking xnat4tests here. By adding the extra exception to be caught everything works fine again.