### PR TITLE
Lazy loading of medimages4tests imports

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -14,7 +14,9 @@ def test_launch(config, launched_xnat):
         login.put(f"/data/archive/projects/{PROJECT}")
 
         # Create subject
-        xsubject = login.classes.SubjectData(label=SUBJECT, parent=login.projects[PROJECT])
+        xsubject = login.classes.SubjectData(
+            label=SUBJECT, parent=login.projects[PROJECT]
+        )
         # Create session
         xsession = login.classes.MrSessionData(label=SESSION, parent=xsubject)
 

--- a/xnat4tests/cli.py
+++ b/xnat4tests/cli.py
@@ -139,9 +139,9 @@ def restart_cli(ctx, loglevel):
 
 @cli.command(
     name="add-data",
-    help="""Adds sample data to the XNAT instance
+    help=f"""Adds sample data to the XNAT instance
 
-DATASET is the name of the dataset to add (out of ['dummydicom'])""",
+DATASET is the name of the dataset to add (out of {AVAILABLE_DATASETS})""",
 )
 @click.argument("dataset", type=click.Choice(AVAILABLE_DATASETS))
 @click.option(

--- a/xnat4tests/data.py
+++ b/xnat4tests/data.py
@@ -6,16 +6,6 @@ import zipfile
 from contextlib import contextmanager
 from pathlib import Path
 from xnat.exceptions import XNATResponseError
-from medimages4tests.dummy.dicom.mri.t1w.siemens.skyra.syngo_d13c import (
-    get_image as t1w_syngo,
-)
-from medimages4tests.dummy.dicom.mri.dwi.siemens.skyra.syngo_d13c import (
-    get_image as dwi_syngo,
-)
-from medimages4tests.dummy.dicom.mri.fmap.siemens.skyra.syngo_d13c import (
-    get_image as fmap_syngo,
-)
-from medimages4tests.mri.neuro.t1w import get_image as openneuro_t1w
 from .base import connect
 from .config import Config
 from .utils import logger
@@ -64,6 +54,15 @@ def add_data(dataset: str, config_name: str or dict = "default"):
         )
 
     if dataset == "dummydicom":
+        from medimages4tests.dummy.dicom.mri.t1w.siemens.skyra.syngo_d13c import (
+            get_image as t1w_syngo,
+        )
+        from medimages4tests.dummy.dicom.mri.dwi.siemens.skyra.syngo_d13c import (
+            get_image as dwi_syngo,
+        )
+        from medimages4tests.dummy.dicom.mri.fmap.siemens.skyra.syngo_d13c import (
+            get_image as fmap_syngo,
+        )
 
         _upload_dicom_data(
             [t1w_syngo(), dwi_syngo(), fmap_syngo()],
@@ -74,6 +73,7 @@ def add_data(dataset: str, config_name: str or dict = "default"):
         )
 
     elif dataset == "openneuro-t1w":
+        from medimages4tests.mri.neuro.t1w import get_image as openneuro_t1w
 
         _upload_directly(
             {"t1w": openneuro_t1w()},
@@ -119,6 +119,9 @@ def add_data(dataset: str, config_name: str or dict = "default"):
         )
 
     elif dataset == "user-training":
+        from medimages4tests.dummy.dicom.mri.fmap.siemens.skyra.syngo_d13c import (
+            get_image as fmap_syngo,
+        )
 
         _upload_dicom_data(
             [t1w_syngo(), fmap_syngo()],

--- a/xnat4tests/registry.py
+++ b/xnat4tests/registry.py
@@ -1,10 +1,10 @@
-import docker
+import docker.models.containers
 from .utils import logger
 from .config import Config
 from .base import docker_network, connect
 
 
-def start_registry(config_name="default"):
+def start_registry(config_name: str = "default") -> docker.models.containers.Container:
 
     config = Config.load(config_name)
 
@@ -38,7 +38,7 @@ def start_registry(config_name="default"):
     return container
 
 
-def stop_registry(config_name="default"):
+def stop_registry(config_name: str = "default") -> None:
 
     config = Config.load(config_name)
 


### PR DESCRIPTION
lazily loads medimages4tests imports so that they don't slow down the cases where they aren't required